### PR TITLE
fix: anisble uses python3

### DIFF
--- a/paper-install.yaml
+++ b/paper-install.yaml
@@ -13,7 +13,9 @@
       file:
         path: /tmp/paper.deb
         state: absent
+    #        the archive is minecraft-data so the expected path for world data must be /minecraft-data hence the destination
+    #        being root
     - name: unarchive world
       unarchive:
         src: /tmp/world.tar.gz
-        dest: /minecraft-data/
+        dest: /

--- a/paper.json
+++ b/paper.json
@@ -16,22 +16,20 @@
   "provisioners": [
     {
       "type": "file",
-      "source": "world.tar.gz",
+      "source": "./world.tar.gz",
       "destination": "/tmp/world.tar.gz"
     },
     {
       "type": "file",
-      "source": "paper.deb",
+      "source": "./paper.deb",
       "destination": "/tmp/paper.deb"
     },
     {
       "type": "ansible-local",
-      "playbook_file": "paper-install.yaml"
-    },
-    {
-      "type": "shell",
-      "inline": [
-        "ls -alh /minecraft-data/"
+      "playbook_file": "paper-install.yaml",
+      "extra_arguments": [
+        "--extra-vars",
+        "ansible_python_interpreter=/usr/bin/python3"
       ]
     }
   ]


### PR DESCRIPTION
the file provisioners use relative paths to point to the source
of files that need to be uploaded to the image builder.